### PR TITLE
drop version numbers from api/core jars

### DIFF
--- a/api/build.sbt
+++ b/api/build.sbt
@@ -10,6 +10,10 @@ scalacOptions ++= Seq(
 
 exportJars := true
 
+artifactName in Compile := { (_, _, artifact: Artifact) => artifact.name + "." + artifact.extension }
+
+artifactName in Test := { (_, _, artifact: Artifact) => artifact.name + "-test." + artifact.extension }
+
 libraryDependencies ++= Seq(
   "org.nlogo" % "NetLogo" % "5.1.0" from
     "http://ccl.northwestern.edu/netlogo/5.1.0/NetLogo.jar"

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -10,6 +10,10 @@ scalacOptions ++= Seq(
 
 exportJars := true
 
+artifactName in Compile := { (_, _, artifact: Artifact) => artifact.name + "." + artifact.extension }
+
+artifactName in Test := { (_, _, artifact: Artifact) => artifact.name + "-test." + artifact.extension }
+
 fork := true
 
 libraryDependencies ++= Seq(


### PR DESCRIPTION
Fixes #139.  The problem with 75bb2154d29994e0ffc6fe0e89c2120bcc33da68 was that it mapped both the normal artifacts and the test artifacts within the SBT project to the same name.  The test artifacts would get written second, and they would overwrite the normal artifacts.  This PR gives the artifacts simple names without causing test artifacts to have name collisions with the other artifacts.
