### PR TITLE
Add change listeners

### DIFF
--- a/core/src/main/scala/uk/ac/surrey/xw/gui/GUI.scala
+++ b/core/src/main/scala/uk/ac/surrey/xw/gui/GUI.scala
@@ -32,7 +32,10 @@ class GUI(
   val widgetKinds: Map[String, WidgetKind[_]])
   extends Subscriber[StateEvent, Publisher[StateEvent]] {
 
-  writer.subscribe(this)
+  writer.subscribe(this, {
+    case SetProperty(_,_,_,fromUI) => !fromUI
+    case _ => true
+  })
 
   val tabs = app.tabs
   val tabPropertyKey = new TabKind[Tab].name
@@ -42,7 +45,7 @@ class GUI(
       event match {
         case AddWidget(widgetKey, propertyMap) ⇒
           addWidget(widgetKey, propertyMap)
-        case SetProperty(widgetKey, propertyKey, propertyValue) ⇒
+        case SetProperty(widgetKey, propertyKey, propertyValue, _) ⇒
           setProperty(widgetKey, propertyKey, propertyValue)
         case RemoveWidget(widgetKey) ⇒
           removeWidget(widgetKey)

--- a/core/src/main/scala/uk/ac/surrey/xw/state/StateEvent.scala
+++ b/core/src/main/scala/uk/ac/surrey/xw/state/StateEvent.scala
@@ -15,7 +15,8 @@ case class AddWidget(
 case class SetProperty(
   val widgetKey: WidgetKey,
   val propertyKey: PropertyKey,
-  val propertyValue: PropertyValue)
+  val propertyValue: PropertyValue,
+  val fromUI: Boolean)
   extends StateEvent
 
 case class RemoveWidget(

--- a/core/src/main/scala/uk/ac/surrey/xw/state/Writer.scala
+++ b/core/src/main/scala/uk/ac/surrey/xw/state/Writer.scala
@@ -86,13 +86,13 @@ class Writer(
     propertyKey: PropertyKey,
     widgetKey: WidgetKey,
     propertyValue: PropertyValue): Unit =
-    set(propertyKey, widgetKey, propertyValue, false)
+    set(propertyKey, widgetKey, propertyValue, fromUI = true)
 
   def set(
     propertyKey: PropertyKey,
     widgetKey: WidgetKey,
     propertyValue: PropertyValue,
-    publishEvent: Boolean): Unit = {
+    fromUI: Boolean): Unit = {
 
     val propertyMap = widgetMap.getOrElse(widgetKey,
       throw XWException("Widget " + widgetKey + " does not exist."))
@@ -100,7 +100,7 @@ class Writer(
     val oldValue = propertyMap.get(pKey)
     if (Some(propertyValue) != oldValue) {
       propertyMap += pKey -> propertyValue
-      if (publishEvent) publish(SetProperty(widgetKey, pKey, propertyValue))
+      publish(SetProperty(widgetKey, pKey, propertyValue, fromUI))
     }
   }
 

--- a/xw/src/main/scala/uk/ac/surrey/xw/extension/prim/OnChange.scala
+++ b/xw/src/main/scala/uk/ac/surrey/xw/extension/prim/OnChange.scala
@@ -1,0 +1,72 @@
+package uk.ac.surrey.xw.extension.prim
+
+import org.nlogo.api.{Argument, Context, DefaultCommand}
+import org.nlogo.api.Syntax.{StringType, commandSyntax, CommandBlockType}
+import org.nlogo.nvm.{AssemblerAssistant, ExtensionContext, CustomAssembled, Context => NvmContext}
+import uk.ac.surrey.xw.api.{PropertyKey, WidgetKey}
+import uk.ac.surrey.xw.extension.{KindInfo, WidgetContextManager}
+import uk.ac.surrey.xw.state.{StateEvent, Writer, SetProperty => SetPropEvent}
+
+import scala.collection.mutable.{Publisher, Subscriber, Map => MutableMap}
+
+case class ChangeListener(func: StateEvent => Unit)  extends Subscriber[StateEvent, Publisher[StateEvent]] {
+  def notify(pub: Publisher[StateEvent], event: StateEvent): Unit = func(event)
+}
+
+object OnChange {
+  val listeners = MutableMap.empty[(WidgetKey, PropertyKey), ChangeListener]
+}
+
+abstract class OnChangePrim(writer: Writer, wcm: WidgetContextManager) extends DefaultCommand with CustomAssembled {
+
+  def addListener(context: Context, widgetKey: WidgetKey, propertyKey: PropertyKey): Unit = {
+    val extContext = context.asInstanceOf[ExtensionContext]
+    val agentSet = extContext.workspace.world.observers
+    // The ip of the block is relative to the ip at *this* point in time. Since the listeners will activate later on,
+    // after this Context has changed, the ip will be lost. Thus, we need to compute the block's ip now. This
+    // prevents us from using HasCommandBlock to run the blocks. BCH 4/19/2015
+    val ip = extContext.nvmContext.ip + 1
+    extContext.nvmContext.activation.procedure.code(ip)
+    val childContext = new NvmContext(extContext.nvmContext, extContext.workspace.world.observer)
+    childContext.agent = extContext.workspace.world.observer
+
+    val listener = ChangeListener { _ => wcm.withContext(widgetKey) { () =>
+      childContext.runExclusiveJob(agentSet, ip)
+    }}
+
+    OnChange.listeners.get((widgetKey, propertyKey)).foreach(writer.removeSubscription)
+
+    writer.subscribe(listener, {
+      case SetPropEvent(`widgetKey`, `propertyKey`, _, true) => true
+      case _ => false
+    })
+
+    OnChange.listeners((widgetKey, propertyKey)) = listener
+  }
+
+  def assemble(a: AssemblerAssistant) {
+    a.block()
+    a.done()
+  }
+}
+
+class OnChange(writer: Writer, kindInfo: KindInfo, wcm: WidgetContextManager) extends OnChangePrim(writer, wcm) {
+
+  override def getSyntax = commandSyntax(Array(StringType, CommandBlockType))
+
+  def perform(args: Array[Argument], context: Context): Unit = {
+    val widgetKey: WidgetKey = args(0).getString
+    val propertyKey: PropertyKey = kindInfo.defaultProperty(widgetKey).key
+    addListener(context, widgetKey, propertyKey)
+  }
+}
+
+class OnChangeProperty(writer: Writer, propertyKey: PropertyKey, wcm: WidgetContextManager)
+  extends OnChangePrim(writer, wcm) {
+
+  override def getSyntax = commandSyntax(Array(CommandBlockType))
+
+  def perform(args: Array[Argument], context: Context): Unit = {
+    addListener(context, wcm.currentContext, propertyKey)
+  }
+}

--- a/xw/src/main/scala/uk/ac/surrey/xw/extension/prim/OnChange.scala
+++ b/xw/src/main/scala/uk/ac/surrey/xw/extension/prim/OnChange.scala
@@ -21,18 +21,19 @@ abstract class OnChangePrim(writer: Writer, wcm: WidgetContextManager) extends D
 
   def addListener(context: Context, widgetKey: WidgetKey, propertyKey: PropertyKey): Unit = {
     val extContext = context.asInstanceOf[ExtensionContext]
-    val agentSet = extContext.workspace.world.observers
+    val ws = extContext.workspace
+    val agentSet = ws.world.observers
     // The ip of the block is relative to the ip at *this* point in time. Since the listeners will activate later on,
     // after this Context has changed, the ip will be lost. Thus, we need to compute the block's ip now. This
     // prevents us from using HasCommandBlock to run the blocks. BCH 4/19/2015
-    val ip = extContext.nvmContext.ip + 1
-    extContext.nvmContext.activation.procedure.code(ip)
+    val ip = extContext.nvmContext.ip
     val childContext = new NvmContext(extContext.nvmContext, extContext.workspace.world.observer)
-    childContext.agent = extContext.workspace.world.observer
+    childContext.agent = ws.world.observer
 
-    val listener = ChangeListener { _ => wcm.withContext(widgetKey) { () =>
-      childContext.runExclusiveJob(agentSet, ip)
-    }}
+    val listener = ChangeListener { _ =>
+      childContext.ip = ip
+      ws.addJobFromJobThread(childContext.makeConcurrentJob(agentSet))
+    }
 
     OnChange.listeners.get((widgetKey, propertyKey)).foreach(writer.removeSubscription)
 

--- a/xw/src/main/scala/uk/ac/surrey/xw/extension/prim/Set.scala
+++ b/xw/src/main/scala/uk/ac/surrey/xw/extension/prim/Set.scala
@@ -33,6 +33,6 @@ class Set(
       try property.encode(propertyValue)
       catch { case e: IllegalArgumentException ⇒ throw XWException(e.getMessage, e) }
 
-    writer.set(property.key, widgetKey, value, true)
+    writer.set(property.key, widgetKey, value, fromUI = false)
   }
 }

--- a/xw/src/main/scala/uk/ac/surrey/xw/extension/prim/SetProperty.scala
+++ b/xw/src/main/scala/uk/ac/surrey/xw/extension/prim/SetProperty.scala
@@ -30,6 +30,6 @@ class SetProperty(
     )
 
     val propertyValue = property.encode(args(0).get)
-    writer.set(propertyKey, widgetKey, propertyValue, true)
+    writer.set(propertyKey, widgetKey, propertyValue, fromUI = false)
   }
 }


### PR DESCRIPTION
@nicolaspayette Here's a first pass. Took me a while to get the command blocks to execute properly, given that they need to execute after their parent `Context` has moved onto other things.

This PR adds a `xw:on-change` primitive, as well as generated `xw:on-*-change` primitives for each widget property.

`xw:on-change <widget-key> <command-block>` executes `<command-block>` every time that widget's default property updates due via the UI. That is, setters should not trigger the command block. The command block is run by the observer in `<widget-key>`'s xw context. Note that setters may trigger the listener if the widget's `updateInState` is triggered by widget-contents changes rather than by UI actions (e.g. using `TextListener` rather focus loss on text fields).

`xw:on-<property-key>-change <command-block>` behaves exactly like `xw:on-change`, except that the widget is taken from the current xw context and the property is specified in the primitive name instead of using the widget's default.

Take a look. Unfortunately, there are no tests, since by nature, the listeners should only run in response to AWT events, and so won't do anything in headless.