### PR TITLE
Fix error when widgets are changed then removed

### DIFF
--- a/core/src/main/scala/uk/ac/surrey/xw/state/Writer.scala
+++ b/core/src/main/scala/uk/ac/surrey/xw/state/Writer.scala
@@ -94,13 +94,18 @@ class Writer(
     propertyValue: PropertyValue,
     fromUI: Boolean): Unit = {
 
-    val propertyMap = widgetMap.getOrElse(widgetKey,
-      throw XWException("Widget " + widgetKey + " does not exist."))
-    val pKey = normalizeString(propertyKey)
-    val oldValue = propertyMap.get(pKey)
-    if (Some(propertyValue) != oldValue) {
-      propertyMap += pKey -> propertyValue
-      publish(SetProperty(widgetKey, pKey, propertyValue, fromUI))
+    widgetMap.get(widgetKey).orElse {
+      if (!fromUI)
+        throw XWException("Widget " + widgetKey + " does not exist.")
+      else
+        None
+    }.foreach { propertyMap =>
+      val pKey = normalizeString(propertyKey)
+      val oldValue = propertyMap.get(pKey)
+      if (Some(propertyValue) != oldValue) {
+        propertyMap += pKey -> propertyValue
+        publish(SetProperty(widgetKey, pKey, propertyValue, fromUI))
+      }
     }
   }
 

--- a/xw/src/main/scala/uk/ac/surrey/xw/extension/prim/OnChange.scala
+++ b/xw/src/main/scala/uk/ac/surrey/xw/extension/prim/OnChange.scala
@@ -29,7 +29,8 @@ abstract class OnChangePrim(writer: Writer, wcm: WidgetContextManager) extends D
     val ws = extContext.workspace.asInstanceOf[AbstractWorkspace]
     OnChange.removeListeners(writer, widgetKey, propertyKey)
 
-    val proc = ws.compileForRun("task [ xw:ask ?1 [ (run ?2 ?3) ] ]", extContext.nvmContext, true)
+    val proc = ws.compileForRun("task [ if member? ?1 xw:widgets [ xw:ask ?1 [ (run ?2 ?3) ] ] ]",
+      extContext.nvmContext, true)
     val activation = new Activation(proc, extContext.nvmContext.activation, 0)
     val askTask = extContext.nvmContext.callReporterProcedure(activation).asInstanceOf[CommandTask]
 


### PR DESCRIPTION
Some test cases:

```
extensions [ xw ]

to test1
  xw:clear-all
  xw:create-tab "foo"
  xw:create-chooser "test" [
    xw:set-items ["one" "two"]
  ]
  xw:remove "test"
end

to test2
  xw:clear-all
  xw:create-tab "foo"
  xw:create-chooser "test" [
    xw:set-items ["one" "two"]
    xw:on-selected-item-change [
      show xw:selected-item
    ]
  ]
  xw:remove "test"
end
```

Although these use with widget creation, the problem affects widget change as well.